### PR TITLE
Add dynamic La Cápsula visual demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,182 +2,38 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>La Cápsula</title>
 <style>
-/* Basic Reset */
-*{margin:0;padding:0;box-sizing:border-box;}
-html,body{height:100%;font-family:'Montserrat',Arial,sans-serif;color:#fff;background:#000;overflow-x:hidden;}
-nav{position:fixed;top:0;left:0;width:100%;display:flex;justify-content:space-between;align-items:center;padding:10px 20px;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);z-index:1000;}
-nav h1{font-size:1.5rem;text-shadow:0 2px 4px rgba(0,0,0,0.6);}
-button.buy{background:#1DE9B6;border:none;padding:10px 20px;font-weight:bold;border-radius:4px;color:#fff;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.4);transition:background 0.3s;}
-button.buy:hover{background:#19c9a4;}
-#scene{position:relative;height:100vh;width:100%;overflow:hidden;}
-#background{position:absolute;top:0;left:0;width:100%;height:100%;background:radial-gradient(circle at 50% 60%,rgba(255,255,255,0.1),transparent 70%);z-index:0;}
-.particle{position:absolute;border-radius:50%;background:radial-gradient(circle,rgba(180,220,255,0.3),rgba(0,0,255,0) 60%);pointer-events:none;}
-.capsule{position:absolute;border-radius:50%;border:2px solid #fff;width:80px;height:80px;display:flex;align-items:center;justify-content:center;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,0.6),rgba(255,255,255,0.1) 40%,rgba(255,255,255,0.05));box-shadow:0 0 8px rgba(255,255,255,0.3);transition:transform 0.2s;}
-.capsule span{font-size:1.2rem;font-weight:bold;text-shadow:0 1px 3px rgba(0,0,0,0.7);pointer-events:none;}
-.tooltip{position:absolute;padding:8px 12px;background:rgba(0,0,0,0.8);border:1px solid #1DE9B6;border-radius:4px;font-size:0.9rem;pointer-events:none;white-space:pre-line;z-index:1001;}
-#info{padding:80px 20px 40px;font-size:1.1rem;text-align:center;background:#000;}
-#info h2{font-size:2rem;margin-bottom:10px;}
-#info p{margin:10px 0;}
-#modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);display:flex;align-items:center;justify-content:center;z-index:2000;display:none;}
-#modal form{background:#111;padding:20px;border-radius:6px;width:90%;max-width:400px;box-shadow:0 0 10px rgba(0,0,0,0.5);}
-#modal label{display:block;margin-top:10px;font-size:0.9rem;}
-#modal input,#modal select{width:100%;padding:8px;margin-top:4px;background:#222;border:1px solid #555;color:#fff;border-radius:4px;}
-#modal button{margin-top:15px;}
-@media(max-width:600px){.capsule{width:60px;height:60px;}}
+html,body{margin:0;padding:0;height:100%;overflow:hidden;background:#000;font-family:Arial,Helvetica,sans-serif;color:#fff}
+#background{position:fixed;top:0;left:0;width:100%;height:100%;background:radial-gradient(circle at center,#000,#111);z-index:0;overflow:hidden}
+.particle{position:absolute;border-radius:50%;width:4px;height:4px;background:rgba(200,220,255,0.6);filter:blur(2px)}
+#field{position:fixed;top:0;left:0;width:100%;height:100%;perspective:800px;transform-style:preserve-3d;z-index:1}
+.capsule{position:absolute;width:80px;height:80px;border-radius:50%;border:2px solid #fff;box-shadow:0 0 8px rgba(255,255,255,0.2),0 4px 12px rgba(0,0,0,0.5),inset 0 0 12px rgba(0,0,0,0.4);background:radial-gradient(circle at 30% 30%,rgba(255,255,255,0.8),rgba(255,255,255,0.1) 60%,rgba(255,255,255,0.05));display:flex;align-items:center;justify-content:center;color:#fff;text-shadow:0 2px 4px rgba(0,0,0,0.6);transform-style:preserve-3d;pointer-events:none;opacity:.25}
+.capsule.front{opacity:1;pointer-events:auto}
+.capsule span{pointer-events:none;font-weight:bold}
+@keyframes drift{0%{transform:translate3d(var(--x),var(--y),-3000px) scale(.2);opacity:.25}50%{transform:translate3d(var(--x),var(--y),0) scale(1);opacity:1}100%{transform:translate3d(var(--x),var(--y),3000px) scale(.2);opacity:.25}}
+#tooltip{position:absolute;display:none;background:rgba(0,0,0,0.8);padding:8px 12px;border-radius:4px;border:1px solid #fff;font-size:12px;white-space:nowrap;pointer-events:none;z-index:2}
+@media(max-width:600px){.capsule{width:60px;height:60px;font-size:12px}}
 </style>
 </head>
 <body>
-<nav>
-<h1>La Cápsula</h1>
-<button class="buy">BUY A CAPSULE</button>
-</nav>
-<div id="scene">
 <div id="background"></div>
-<!-- Capsules -->
-</div>
-<section id="info">
-<h2>What is La Cápsula?</h2>
-<p>Be part of a unique digital living artwork. Each capsule is a unique spot in this infinite breathing field.</p>
-<p id="counter">0 / 9 joined</p>
-<button class="buy">BUY A CAPSULE</button>
-</section>
-<div id="modal">
-<form id="buyForm">
-<h3>Claim a Capsule</h3>
-<label for="capsuleSelect">Choose Capsule</label>
-<select id="capsuleSelect" required></select>
-<label for="message">Message (max 100 chars)</label>
-<input id="message" maxlength="100" required>
-<label for="url">Link (https, optional)</label>
-<input id="url" pattern="https?://.*">
-<button type="submit" class="buy">Submit</button>
-</form>
-</div>
+<div id="field"></div>
+<div id="tooltip"></div>
 <script>
-/* ----- Data Structures ----- */
-const capsuleData=[];
-for(let i=1;i<=9;i++){
- capsuleData.push({id:i,x:Math.random()*600-300,y:Math.random()*400-200,z:Math.random()*600-300,phiX:Math.random()*Math.PI*2,phiY:Math.random()*Math.PI*2,phiZ:Math.random()*Math.PI*2,msg:'',url:'',claimed:false});
-}
-const particles=[];
-for(let i=0;i<20;i++){
- particles.push({el:null,x:Math.random()*window.innerWidth,y:Math.random()*window.innerHeight,amp:50+Math.random()*50,speed:0.2+Math.random()*0.3,phase:Math.random()*Math.PI*2,size:20+Math.random()*30});
-}
-
-/* ----- Elements ----- */
-const scene=document.getElementById('scene');
+const capsulesData=Array.from({length:10000},(_,i)=>({id:i+1,photoUrl:`photos/${i+1}.jpg`,message:`User message ${i+1}`,link:''}));
+const field=document.getElementById('field');
+const tooltip=document.getElementById('tooltip');
+const duration=45;const delayStep=5;const vw=window.innerWidth;const vh=window.innerHeight;
+// particles
 const bg=document.getElementById('background');
-const counter=document.getElementById('counter');
-const modal=document.getElementById('modal');
-const form=document.getElementById('buyForm');
-const select=document.getElementById('capsuleSelect');
-const tooltip=document.createElement('div');
-tooltip.className='tooltip';
-scene.appendChild(tooltip);
-let tooltipTarget=null;
-
-/* ----- Initialize ----- */
-function init(){
- // create particles
- particles.forEach(p=>{
-  const d=document.createElement('div');
-  d.className='particle';
-  d.style.width=d.style.height=p.size+'px';
-  scene.appendChild(d);p.el=d;
- });
- // create capsules
- capsuleData.forEach(c=>{
-  const d=document.createElement('div');
-  d.className='capsule';
-  const span=document.createElement('span');
-  span.textContent=c.id;d.appendChild(span);
-  scene.appendChild(d);c.el=d;
-  d.addEventListener('mouseenter',()=>showTooltip(c));
-  d.addEventListener('mouseleave',hideTooltip);
-  d.addEventListener('click',(e)=>{showTooltip(c);e.stopPropagation();});
- });
- updateSelectOptions();
- document.querySelectorAll('.buy').forEach(btn=>btn.addEventListener('click',openModal));
- modal.addEventListener('click',e=>{if(e.target===modal)closeModal();});
- document.body.addEventListener('click',e=>{if(tooltipTarget&&!tooltip.contains(e.target))hideTooltip();});
- form.addEventListener('submit',claimCapsule);
- requestAnimationFrame(animate);
-}
-
-/* ----- Animation ----- */
-function animate(t){
- const time=t/1000;
- // particles
- particles.forEach(p=>{
-  p.phase+=p.speed*0.01;
-  const x=p.x+p.amp*Math.sin(time*p.speed+p.phase);
-  const y=p.y+p.amp*Math.cos(time*p.speed+p.phase);
-  p.el.style.transform=`translate(${x}px,${y}px)`;
- });
- // capsules
- capsuleData.forEach(c=>{
-  const range=300;
-  c.x+=Math.sin(time*0.2+c.phiX)*0.3;
-  c.y+=Math.cos(time*0.15+c.phiY)*0.3;
-  c.z+=Math.sin(time*0.25+c.phiZ)*0.3;
-  // wrap
-  if(c.x>range) c.x=-range; if(c.x<-range) c.x=range;
-  if(c.y>range) c.y=-range; if(c.y<-range) c.y=range;
-  if(c.z>range) c.z=-range; if(c.z<-range) c.z=range;
-  const scale=1+(c.z/300);
-  c.el.style.transform=`translate(calc(50% + ${c.x}px),calc(50% + ${c.y}px)) scale(${scale})`;
- });
- // background breathing
- const glow=0.5+0.5*Math.sin(time*0.5);
- bg.style.background=`radial-gradient(circle at 50% 60%,rgba(255,255,255,${0.05+glow*0.05}),transparent 70%)`;
- requestAnimationFrame(animate);
-}
-
-/* ----- Tooltip ----- */
-function showTooltip(c){
- tooltipTarget=c;
- const rect=c.el.getBoundingClientRect();
- tooltip.style.display='block';
- tooltip.innerHTML=c.claimed?`<strong>Capsule #${c.id}</strong><br>${c.msg}${c.url?`<br><a href="${c.url}" target="_blank">${c.url}</a>`:''}`:`Capsule #${c.id} – Empty`;
- const tooltipRect=tooltip.getBoundingClientRect();
- const top=rect.top-tooltipRect.height-8;
- const left=rect.left+(rect.width-tooltipRect.width)/2;
- tooltip.style.top=`${top}px`;
- tooltip.style.left=`${left}px`;
-}
-function hideTooltip(){
- tooltip.style.display='none';
- tooltipTarget=null;
-}
-
-/* ----- Modal Logic ----- */
-function openModal(){modal.style.display='flex';}
-function closeModal(){modal.style.display='none';form.reset();}
-function updateSelectOptions(){
- select.innerHTML='';
- capsuleData.filter(c=>!c.claimed).forEach(c=>{
-  const op=document.createElement('option');
-  op.value=c.id;op.textContent=c.id;select.appendChild(op);
- });
- if(select.options.length===0){select.disabled=true;}
- counter.textContent=`${capsuleData.filter(c=>c.claimed).length} / 9 joined`;
-}
-function claimCapsule(e){
- e.preventDefault();
- const id=parseInt(select.value,10);
- const cap=capsuleData.find(c=>c.id===id);
- if(!cap||cap.claimed)return;
- cap.msg=document.getElementById('message').value.trim();
- cap.url=document.getElementById('url').value.trim();
- cap.claimed=true;
- updateSelectOptions();
- closeModal();
- if(tooltipTarget===cap)showTooltip(cap);
-}
-window.addEventListener('load',init);
+const particles=[];const pCount=20+Math.floor(Math.random()*11);
+for(let i=0;i<pCount;i++){const d=document.createElement('div');d.className='particle';bg.appendChild(d);particles.push({el:d,ox:Math.random()*vw,oy:Math.random()*vh,ax:50+Math.random()*50,ay:50+Math.random()*50,sx:.5+Math.random(),sy:.5+Math.random(),phase:Math.random()*Math.PI*2});}
+function animateParticles(t){particles.forEach(p=>{const x=p.ox+Math.sin(t/1000*p.sx+p.phase)*p.ax;const y=p.oy+Math.cos(t/1000*p.sy+p.phase)*p.ay;p.el.style.transform=`translate3d(${x}px,${y}px,0)`;p.el.style.opacity=0.1+0.2*(0.5+Math.sin(t/1000+p.phase)/2);});requestAnimationFrame(animateParticles);}requestAnimationFrame(animateParticles);
+// capsules
+capsulesData.forEach((c,i)=>{const d=document.createElement('div');d.className='capsule';d.innerHTML=`<span>${c.id}</span>`;const x=Math.random()*vw*4-vw*2;const y=Math.random()*vh*4-vh*2;d.style.setProperty('--x',x+'px');d.style.setProperty('--y',y+'px');d.style.animation=`drift ${duration}s linear forwards`;const delay=i*delayStep;d.style.animationDelay=delay+'s';field.appendChild(d);const frontTime=delay+duration/2;setTimeout(()=>d.classList.add('front'),frontTime*1000);setTimeout(()=>d.classList.remove('front'),(frontTime+5)*1000);d.addEventListener('click',e=>{if(!d.classList.contains('front'))return;tooltip.style.display='block';tooltip.textContent=c.message;const r=d.getBoundingClientRect();tooltip.style.left=r.left+r.width/2-tooltip.offsetWidth/2+'px';tooltip.style.top=r.top-tooltip.offsetHeight-8+'px';e.stopPropagation();});});
+document.addEventListener('click',()=>tooltip.style.display='none');
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul `index.html` with a self-contained demo
- add inline CSS for glasslike capsules and infinite field
- generate 10,000 capsule objects and animate them
- animate subtle background particles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68427f33a278832bbbb2de7e5ba88430